### PR TITLE
Fix flagsmith example

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,13 @@
-import flagsmith from "flagsmith";
+import flagsmith from "flagsmith/isomorphic";
 import { FlagsmithProvider } from "flagsmith/react";
+const environmentID =  "<YOUR_ENVIRONMENT_KEY>"
+function MyApp({ Component, pageProps, flagsmithState }) {
 
-function MyApp({ Component, pageProps }) {
   return (
     <FlagsmithProvider
       options={{
-        environmentID: "<YOUR_ENVIRONMENT_KEY>",
+        state:flagsmithState, // passes the initial SSR flagsmith state to prevent flickering
+        environmentID,
       }}
       flagsmith={flagsmith}
     >
@@ -13,5 +15,14 @@ function MyApp({ Component, pageProps }) {
     </FlagsmithProvider>
   );
 }
+
+
+MyApp.getInitialProps = async () => {
+    await flagsmith.init({ // fetches flags on the server
+        environmentID,
+    });
+    return { flagsmithState: flagsmith.getState() }
+}
+
 
 export default MyApp;


### PR DESCRIPTION
Here there were a few problems:

- With SSR and technologies such as next you should use flagsmith/isomorphic which deals with a mixture of node and frontend
- Since fetching flags is asynchronous you'd need to either show a loader on SSR or more ideally await fetching flags, I've added the latter in MyApp.getInitialProps
- In relation to the above, we can use the SSR data from Flagsmith to prevent fetching on the client if we want you could add in the like ``preventFetch: !!flagsmithState`` in the options object